### PR TITLE
Removed default coverage reporter so that options files will be used

### DIFF
--- a/nyc/README.md
+++ b/nyc/README.md
@@ -10,7 +10,7 @@ Optional:
 |------------|-------------------------------------------------------------------------------------------------|
 |NYC_PORT    | The TCP port used by the launcher script to communicate with the worker script (default: `8123`)|
 |NYC_PATH    | The path to the `nyc` executable (default: `"node_modules/.bin/nyc"`)                           |
-|NYC_REPORTER| The `nyc` reporter (default: `"lcov"`)                                                          |
+|NYC_REPORTER| The `nyc` reporter (If not specified will use value from nyc config files)                      |
 
 ## Troubleshooting
 Enable the [diagnostic log](https://marketplace.visualstudio.com/items?itemName=hbenl.vscode-mocha-test-adapter#troubleshooting) to see log messages from the launcher script.

--- a/nyc/index.ts
+++ b/nyc/index.ts
@@ -18,12 +18,13 @@ process.once('message', async (workerArgs: WorkerArgs) => {
 		};
 
 		const nycPath = path.resolve(workerArgs.cwd, process.env['NYC_PATH'] || "node_modules/.bin/nyc");
-		const nycReporter = process.env['NYC_REPORTER'] || 'lcov';
+		const nycReporter = process.env['NYC_REPORTER'];
+		const nycOptions = nycReporter ? [`--reporter=${nycReporter}`] : []
 
 		spawn(
 			nycPath,
 			[
-				`--reporter=${nycReporter}`,
+				...nycOptions,
 				process.execPath,
 				workerArgs.workerScript!,
 				JSON.stringify(ipcOpts)


### PR DESCRIPTION
Since a `--reporter` is always specified there is no way to use a project specific nyc config file (.nycrc etc). If we remove the default then the config file value will be used if no env variable is set